### PR TITLE
フローティングウィンドウのクローズボタンが動作しない不具合を修正 #4

### DIFF
--- a/src/components/provider/Window/index.tsx
+++ b/src/components/provider/Window/index.tsx
@@ -15,6 +15,7 @@ export const FloatingWindowProvider = ({ children }: { children?: React.ReactNod
                     zIndex: 1000,
                 }}
                 initialLoc={[100, 100]}
+                onClose={windowPrefs.onClose}
             >
                 {windowPrefs.contents}
             </FloatingWindow>

--- a/src/dataflow/windows/floatingWindowAtom.tsx
+++ b/src/dataflow/windows/floatingWindowAtom.tsx
@@ -5,6 +5,7 @@ export type FloatingWindowPrefs = {
     contents: React.ReactNode;
     title: string;
     show: boolean;
+    onClose?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export const floatingWindowAtom = atom<FloatingWindowPrefs>({


### PR DESCRIPTION
## 概要
フローティングウィンドウのクローズボタンが動作しない不具合を修正した

## 変更点
フローティングウィンドウのクローズボタンにイベントハンドラを追加