### PR TITLE
fix: 38,48 iOSでトップメニューが下揃えにならない不具合を修正 #25

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ export default function Home() {
                         <Container
                             css={{
                                 justifyContent: 'space-between',
-                                alignItems: 'end',
+                                alignItems: 'flex-end',
                                 width: '100%',
                                 height: 46,
                                 padding: '0px 20px',
@@ -45,7 +45,7 @@ export default function Home() {
                             <SvgIcon>
                                 <Icon />
                             </SvgIcon>
-                            <MenuSection css={{ alignItems: 'end' }} />
+                            <MenuSection css={{ alignItems: 'flex-end' }} />
                             <ThemeSection />
                         </Container>
                         <ToolMenues


### PR DESCRIPTION
## 概要
iOSのSafari及びChromeで、トップメニューが下揃えにならない不具合を修正した
